### PR TITLE
Handle UDP open failures more robustly

### DIFF
--- a/app/t50_net/slvnet.c
+++ b/app/t50_net/slvnet.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <unistd.h>
 #include "defs.h"
 #include "defs_pkt.h"
 #include "NSEnum.h"

--- a/app/t50_net/svrnet.c
+++ b/app/t50_net/svrnet.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <unistd.h>
 #include "defs.h"
 #include "defs_pkt.h"
 #include "prim.h"


### PR DESCRIPTION
## Summary
- harden `_TftpcOpen` by checking for negative sockets, propagating libuv failures, and releasing partially initialized handles with error strings
- update `_SvrnetUdpOpen` and `_SlvnetUdpOpen` to return error codes, close sockets on failure paths, and avoid leaving timers scheduled incorrectly
- add missing POSIX includes so the UDP open helpers can call `close` when cleaning up descriptors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de1c4a781c83298cd7db7884f43bf0